### PR TITLE
[BUG] No module named 'torch._six'

### DIFF
--- a/util/misc.py
+++ b/util/misc.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import torch
 import torch.distributed as dist
-from torch._six import inf
+from torch import inf
 
 
 class SmoothedValue(object):


### PR DESCRIPTION
Torch does not seem to support torch._six anymore and it has been removed.
Refer - https://github.com/pytorch/pytorch/pull/94709